### PR TITLE
Fix an obsolete dependency libsystemd-daemon

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ PKG_CHECK_MODULES([GIO_UNIX], [gio-unix-2.0               >= 2.30.0])
 PKG_CHECK_MODULES([GLIB],     [glib-2.0                   >= 2.30.0])
 PKG_CHECK_MODULES([GOBJECT],  [gobject-2.0                >= 2.30.0])
 PKG_CHECK_MODULES([DBUS],     [dbus-1                     >= 1.4.10])
-PKG_CHECK_MODULES([SYSTEMD],  [libsystemd-daemon          >= 37    ])
+PKG_CHECK_MODULES([SYSTEMD],  [libsystemd                 >= 37    ])
 PKG_CHECK_MODULES([PCL],      [persistence_client_library >= 0.6.0 ])
 
 # Choose NodeStateMachine


### PR DESCRIPTION
The libsystemd-daemon component referred to from within configure.ac is not available in Ubuntu Trusty which is referenced as a recommended platform for building the project.
The replacement component is libsystemd.
I'm not completely sure that the required minimal version number of 37 is still relevant, the libsystemd version on my Trusty machine reported by pkg-config is 229 which is way higher that the mentioned 37. Build successfully completes after the change. The 'check' make target does not, but that's a different story.

https://at.projects.genivi.org/jira/browse/NSM-1