### PR TITLE
Solved pError related bug

### DIFF
--- a/NodeStateManager/NodeStateManager.c
+++ b/NodeStateManager/NodeStateManager.c
@@ -1801,14 +1801,17 @@ static NsmErrorStatus_e NSM__enOnHandleRegisterLifecycleClient(const gchar *sBus
     else
     {
       enRetVal = NsmErrorStatus_Dbus;
-      DLT_LOG(NsmContext, DLT_LOG_INFO, DLT_STRING("NSM: Failed to register new lifecycle consumer. D-Bus error."),
-                                        DLT_STRING(" Bus name: "),           DLT_STRING(sBusName                 ),
-                                        DLT_STRING(" Obj name: "),           DLT_STRING(sObjName                 ),
-                                        DLT_STRING(" Timeout: " ),           DLT_UINT(  u32TimeoutMs             ),
-                                        DLT_STRING(" Registered mode(s): "), DLT_INT(   u32ShutdownMode          ),
-                                        DLT_STRING(" Error: "),              DLT_STRING(pError->message          ));
-
-      g_error_free(pError);
+      if(pError != NULL)
+      {
+        DLT_LOG(NsmContext, DLT_LOG_INFO, DLT_STRING("NSM: Failed to register new lifecycle consumer. D-Bus error."),
+                                          DLT_STRING(" Bus name: "),           DLT_STRING(sBusName                 ),
+                                          DLT_STRING(" Obj name: "),           DLT_STRING(sObjName                 ),
+                                          DLT_STRING(" Timeout: " ),           DLT_UINT(  u32TimeoutMs             ),
+                                          DLT_STRING(" Registered mode(s): "), DLT_INT(   u32ShutdownMode          ),
+                                          DLT_STRING(" Error: "),              DLT_STRING(pError->message          ));
+        g_error_free(pError);
+        pError = NULL;
+      }
     }
   }
   else


### PR DESCRIPTION
This patch is applied to avoid segmentation fault.
pError == NULL value can stop NSM, hence putting if condition before dlt print.

Change-Id: I96f7e25ce03e7d82b500d818e097e05413701895
Signed-off-by: Ratnesh Zinzuwadia <ratnesh_zin@yahoo.com>