### PR TITLE
Fix client validation in LifecycleRequestComplete

### DIFF
--- a/NodeStateAccess/NodeStateAccess.c
+++ b/NodeStateAccess/NodeStateAccess.c
@@ -844,7 +844,7 @@ static gboolean NSMA__boOnHandleLifecycleRequestComplete(NodeStateConsumer     *
   NsmErrorStatus_e enErrorStatus = NsmErrorStatus_NotSet;
 
   /* Check if the client is the one, we are waiting for. */
-  if(NSMA__pCurrentLcConsumer == (NodeStateLifeCycleConsumer*) u32RequestId)
+  if(u32RequestId == (guint) NSMA__pCurrentLcConsumer)
   {
     enErrorStatus = NsmErrorStatus_Ok;
     /* The client is the expected one. Pass the status to the NSM. */


### PR DESCRIPTION
The client is validated by comparing the client handle and request ID
received as a part of D-Bus call LifecycleRequestComplete. The reqeust
ID is generated by converting the client handle to guint, which is 32
bit unsigned int. The client handle is a pointer which can be of 64 bits
in size on 64 bit machine. The existing comparison between client handle
and request ID is casting request ID to a pointer type, which can give
wrong results when comparting against a 64 bit pointer. This patch fixes
it by modifying the comparision to cast the client handle to 32 bit
instead.

Signed-off-by: Vishal Thanki <vishalthanki@gmail.com>